### PR TITLE
fix: Copyright Symbol size

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -168,12 +168,20 @@ export default function Footer() {
           >
             <Typography
               sx={{
+                fontSize: 16,
+                pr: 0.5
+              }}
+            >
+              &copy;
+            </Typography>
+            <Typography
+              sx={{
                 fontSize: 10,
                 fontWeight: 500,
                 alignSelf: "center",
               }}
             >
-               &copy; Copyright 2021 Glowdsgn All Rights Reserved
+              Copyright 2021 Glowdsgn All Rights Reserved
             </Typography>
           </Box>
 


### PR DESCRIPTION
close #3 
![image](https://github.com/user-attachments/assets/f36829be-3eb0-4ca7-bff8-663320ed0dab)
